### PR TITLE
[SH-11341] 메타데이터 제외 로직 수정

### DIFF
--- a/build-logic/src/main/kotlin/com/shopl/sdg/build_logic/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/com/shopl/sdg/build_logic/KotlinAndroid.kt
@@ -24,7 +24,11 @@ internal fun Project.configureAndroid(
         }
         packaging {
             resources {
-                excludes.add("META-INF/**")
+                excludes.apply {
+                    add("META-INF/AL2.0")
+                    add("META-INF/LGPL2.1")
+                    add("META-INF/licenses/**")
+                }
             }
         }
 

--- a/build-logic/src/main/kotlin/com/shopl/sdg/build_logic/PublishingConfig.kt
+++ b/build-logic/src/main/kotlin/com/shopl/sdg/build_logic/PublishingConfig.kt
@@ -2,7 +2,7 @@ package com.shopl.sdg.build_logic
 
 object PublishingConfig {
     const val GROUP = "com.shoplworks"
-    const val VERSION = "1.0.0"
+    const val VERSION = "1.0.1"
 
     const val SDG_ARTIFACT_ID = "SDG-Android"
     const val SDG_COMMON_ARTIFACT_ID = "SDG-Android-Common"


### PR DESCRIPTION
## JIRA
[SH-11341](https://shoplworks.atlassian.net/browse/SH-11341)

## 작업사항
- `enum class` 등은 접근이 가능하나 `@Composable` 어노테이션이 붙은 함수들은 `import`가 불가능한 버그 수정 
  - 메타데이터 제외 로직을 일부 메타데이터만 제외하도록 수정

## 리뷰 요청 및 특이사항
`Gradle`의 `packaging.resources.excludes` 설정으로 `META-INF/**`를 전부 제외하면서, AAR 내부에 들어가야 할 Kotlin 메타데이터(`META-INF/kotlin/*.kotlin_module`)까지 삭제되어 컴포저블들이 import 되지 않는 버그가 있었습니다.

`Compose` 함수 등은 이 `.kotlin_module` 메타정보를 보고 `@Composable` 어노테이션을 인식하게 되는데 이 부분이 제외되어서 `import`가 불가능했던 것이 원인이었습니다.

테스트 시 SDG로의 자동완성이 되는 것만 확인하고 배포를 해서 잡아내지를 못했네요 😭

[SH-11341]: https://shoplworks.atlassian.net/browse/SH-11341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ