### PR TITLE
[SH-11231] 아이콘 플러그인 연동 workflow 수정

### DIFF
--- a/.github/workflows/auto-pr-update-icon.yml
+++ b/.github/workflows/auto-pr-update-icon.yml
@@ -16,11 +16,20 @@ jobs:
           script: |
             const branchName = context.ref.replace('refs/heads/', '');
 
-            await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: "아이콘 업데이트",
-              head: branchName,
-              base: "main",
-              body: "아이콘 변경사항이 있습니다."
-            });
+            try {
+              await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "아이콘 업데이트",
+                head: branchName,
+                base: "main",
+                body: "아이콘 변경사항이 있습니다."
+              });
+              console.log("새 PR을 생성했습니다.");
+            } catch (e) {
+              if (e.status === 422 && e.message.includes("A pull request already exists")) {
+                console.log("이미 PR이 존재하므로 생성 작업을 건너뜁니다.");
+              } else {
+                throw e;
+              }
+            }


### PR DESCRIPTION
## JIRA
[SH-11231](https://shoplworks.atlassian.net/browse/SH-11231)

## 작업사항
- 동일 PR 생성 시 예외 처리


## 리뷰 요청 및 특이사항
아이콘 플러그인에 대한 action trigger는 `update/icon`에 대한 push를 감지하고 있습니다.
디자이너 분들이 아이콘 플러그인 사용 시 PR이 닫히기 전 여러 번 아이콘을 추출하면 변경사항이 쌓이게 되는데, 이 때 동일 PR로 생성되기 때문에 workflow에서 아래와 같은 예외가 발생합니다.
```
Error: Unhandled error: HttpError: Validation Failed: {"resource":"PullRequest","code":"custom","message":"A pull request already exists for shopl:update/icon."}
```
merge 하는데에는 이상은 없지만 다음과 같이 실패 처리가 되기 때문에 이를 방지하고자 합니다.
(실패 처리에 대한 문의 방지 및 추후 CI 도입 고려)
<img width="741" alt="스크린샷 2025-06-05 오후 1 27 08" src="https://github.com/user-attachments/assets/9da1ff30-86d8-4e3d-819b-a7f14c0b176a" />


[SH-11231]: https://shoplworks.atlassian.net/browse/SH-11231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ