### PR TITLE
[SH-11942] SDG 배포 상태 Polling 시간 조정

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -169,7 +169,7 @@ jobs:
         run: |
           PUBLISH_ID="${{ steps.publish_upload.outputs.publish_id }}"
           for i in {1..20}; do
-            sleep 30
+            sleep 120
             RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://central.sonatype.com/api/v1/publisher/status?id=$PUBLISH_ID" \
               -H "Authorization: Bearer ${{ secrets.SONATYPE_PUBLISH_TOKEN }}")
             HTTP_CODE=$(echo "$RESPONSE" | tail -n1)


### PR DESCRIPTION
## JIRA
[SH-11942](https://shoplworks.atlassian.net/browse/SH-11942)

## 작업사항
- 배포 상태를 체크하는 polling 시간이 짧아 배포가 되었음에도 알림이 안 가는 이슈가 있어서 시간 조정 했습니다.
  - 30초 간격 20번 -> 2분 간격 20번

[SH-11942]: https://shoplworks.atlassian.net/browse/SH-11942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ