### PR TITLE
[SH-12090] [Android] SDG Component > Ghost Button 레거시 수정

### DIFF
--- a/sdg/src/main/java/com/shopl/sdg/component/button/ghost/SDGGhostButton.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/button/ghost/SDGGhostButton.kt
@@ -1,7 +1,6 @@
 package com.shopl.sdg.component.button.ghost
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,14 +21,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.shopl.sdg_common.ext.clickable
 import com.shopl.sdg_common.foundation.SDGColor
-import com.shopl.sdg_common.ui.components.IOText
-import com.shopl.sdg_common.ui.components.IOTypeface
+import com.shopl.sdg_common.ui.components.SDGImage
+import com.shopl.sdg_common.ui.components.SDGText
 import com.shopl.sdg_resource.R
 
 /**
@@ -47,14 +44,12 @@ fun SDGGhostButton(
     onClick: () -> Unit,
     isFillMaxWidth: Boolean = false,
     enable: Boolean = true,
-    labelTypeface: IOTypeface = IOTypeface.REGULAR,
     @DrawableRes leftIcon: Int? = null,
     leftIconTint: Color? = null,
     @DrawableRes rightIcon: Int? = null,
     rightIconTint: Color? = null,
     marginValues: PaddingValues = PaddingValues(),
 ) {
-
     Box(
         modifier = if (isFillMaxWidth) {
             Modifier.fillMaxWidth()
@@ -91,35 +86,30 @@ fun SDGGhostButton(
             horizontalArrangement = Arrangement.Center
         ) {
             if (leftIcon != null && leftIconTint != null) {
-                Image(
+                SDGImage(
                     modifier = Modifier.size(14.dp),
-                    painter = painterResource(id = leftIcon),
+                    resId = leftIcon,
                     contentDescription = null,
-                    colorFilter = ColorFilter.tint(
-                        color = leftIconTint
-                    )
+                    color = leftIconTint
                 )
                 Spacer(modifier = Modifier.width(size.gap))
             }
-            IOText(
+            SDGText(
                 text = label,
                 textColor = labelColor,
-                fontSize = size.labelSize,
-                typeface = labelTypeface,
+                typography = size.typography
             )
             if (rightIcon != null && rightIconTint != null) {
                 Spacer(modifier = Modifier.width(size.gap))
-                Image(
-                    painter = painterResource(id = rightIcon),
+
+                SDGImage(
+                    resId = rightIcon,
                     contentDescription = null,
-                    colorFilter = ColorFilter.tint(
-                        color = rightIconTint
-                    )
+                    color = rightIconTint
                 )
             }
         }
     }
-
 }
 
 @Composable

--- a/sdg/src/main/java/com/shopl/sdg/component/button/ghost/SDGGhostButton.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/button/ghost/SDGGhostButton.kt
@@ -4,12 +4,10 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -125,75 +123,8 @@ fun SDGGhostButton(
 }
 
 @Composable
-fun RowScope.SDGGhostButton(
-    weight: Float,
-    size: SDGGhostButtonSize,
-    label: String,
-    labelColor: Color,
-    onClick: () -> Unit,
-    enable: Boolean = true,
-    labelTypeface: IOTypeface = IOTypeface.REGULAR,
-    @DrawableRes leftIcon: Int? = null,
-    leftIconTint: Color? = null,
-    @DrawableRes rightIcon: Int? = null,
-    rightIconTint: Color? = null,
-    marginValues: PaddingValues = PaddingValues(),
-) {
-    Box(Modifier.weight(weight)) {
-        SDGGhostButton(
-            isFillMaxWidth = true,
-            enable = enable,
-            size = size,
-            label = label,
-            labelColor = labelColor,
-            labelTypeface = labelTypeface,
-            leftIcon = leftIcon,
-            leftIconTint = leftIconTint,
-            rightIcon = rightIcon,
-            rightIconTint = rightIconTint,
-            marginValues = marginValues,
-            onClick = onClick,
-        )
-    }
-}
-
-@Composable
-fun BoxScope.SDGGhostButton(
-    alignment: Alignment,
-    isFillMaxWidth: Boolean,
-    size: SDGGhostButtonSize,
-    label: String,
-    labelColor: Color,
-    onClick: () -> Unit,
-    enable: Boolean = true,
-    labelTypeface: IOTypeface = IOTypeface.REGULAR,
-    @DrawableRes leftIcon: Int? = null,
-    leftIconTint: Color? = null,
-    @DrawableRes rightIcon: Int? = null,
-    rightIconTint: Color? = null,
-    marginValues: PaddingValues = PaddingValues(),
-) {
-    Box(Modifier.align(alignment)) {
-        SDGGhostButton(
-            isFillMaxWidth = isFillMaxWidth,
-            enable = enable,
-            size = size,
-            label = label,
-            labelColor = labelColor,
-            labelTypeface = labelTypeface,
-            leftIcon = leftIcon,
-            leftIconTint = leftIconTint,
-            rightIcon = rightIcon,
-            rightIconTint = rightIconTint,
-            marginValues = marginValues,
-            onClick = onClick,
-        )
-    }
-}
-
-@Composable
 @Preview
-private fun PrevSDGGhostButton() {
+private fun PreviewSDGGhostButton() {
     Surface(Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
@@ -218,37 +149,6 @@ private fun PrevSDGGhostButton() {
                 labelColor = SDGColor.Neutral700,
                 onClick = {}
             )
-
-
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-
-                SDGGhostButton(
-                    enable = false,
-                    weight = 1f,
-                    size = SDGGhostButtonSize.Medium,
-                    label = "작성하기",
-                    labelColor = SDGColor.Neutral700,
-                    onClick = {}
-                )
-
-                SDGGhostButton(
-                    enable = false,
-                    weight = 1f,
-                    size = SDGGhostButtonSize.Medium,
-                    label = "작성하기",
-                    labelColor = SDGColor.Neutral700,
-                    onClick = {}
-                )
-
-                SDGGhostButton(
-                    enable = false,
-                    weight = 1f,
-                    size = SDGGhostButtonSize.Medium,
-                    label = "작성하기",
-                    labelColor = SDGColor.Neutral700,
-                    onClick = {}
-                )
-            }
         }
     }
 }

--- a/sdg/src/main/java/com/shopl/sdg/component/button/ghost/SDGGhostButtonSize.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/button/ghost/SDGGhostButtonSize.kt
@@ -1,22 +1,21 @@
 package com.shopl.sdg.component.button.ghost
 
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.shopl.sdg_common.foundation.typography.SDGTypography
 
 sealed class SDGGhostButtonSize(
     val height: Dp,
     val horizontalPadding: Dp,
     val gap: Dp,
-    val labelSize: TextUnit,
+    val typography: SDGTypography,
     val rippleRadius: Dp,
 ) {
     data object Large : SDGGhostButtonSize(
         height = 42.dp,
         horizontalPadding = 16.dp,
         gap = 6.dp,
-        labelSize = 16.sp,
+        typography = SDGTypography.Body1R,
         rippleRadius = 14.dp,
     )
 
@@ -24,15 +23,15 @@ sealed class SDGGhostButtonSize(
         height = 36.dp,
         horizontalPadding = 10.dp,
         gap = 4.dp,
-        labelSize = 14.sp,
+        typography = SDGTypography.Body2R,
         rippleRadius = 12.dp,
     )
 
     data object Small : SDGGhostButtonSize(
         height = 28.dp,
-        horizontalPadding = 6.dp,
+        horizontalPadding = 8.dp,
         gap = 2.dp,
-        labelSize = 12.sp,
+        typography = SDGTypography.Body3R,
         rippleRadius = 9.dp,
     )
 }

--- a/sdg/src/main/java/com/shopl/sdg/component/button/ghost/SDGGhostButtonSize.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/button/ghost/SDGGhostButtonSize.kt
@@ -2,6 +2,12 @@ package com.shopl.sdg.component.button.ghost
 
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing10
+import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing16
+import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing2
+import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing4
+import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing6
+import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing8
 import com.shopl.sdg_common.foundation.typography.SDGTypography
 
 sealed class SDGGhostButtonSize(
@@ -13,24 +19,24 @@ sealed class SDGGhostButtonSize(
 ) {
     data object Large : SDGGhostButtonSize(
         height = 42.dp,
-        horizontalPadding = 16.dp,
-        gap = 6.dp,
+        horizontalPadding = Spacing16,
+        gap = Spacing6,
         typography = SDGTypography.Body1R,
         rippleRadius = 14.dp,
     )
 
     data object Medium : SDGGhostButtonSize(
         height = 36.dp,
-        horizontalPadding = 10.dp,
-        gap = 4.dp,
+        horizontalPadding = Spacing10,
+        gap = Spacing4,
         typography = SDGTypography.Body2R,
         rippleRadius = 12.dp,
     )
 
     data object Small : SDGGhostButtonSize(
         height = 28.dp,
-        horizontalPadding = 8.dp,
-        gap = 2.dp,
+        horizontalPadding = Spacing8,
+        gap = Spacing2,
         typography = SDGTypography.Body3R,
         rippleRadius = 9.dp,
     )

--- a/sdg/src/main/java/com/shopl/sdg/component/util/button/ghost/SDGGhostButton.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/util/button/ghost/SDGGhostButton.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.shopl.sdg.component.button.ghost.SDGGhostButton
 import com.shopl.sdg.component.button.ghost.SDGGhostButtonSize
-import com.shopl.sdg_common.ui.components.IOTypeface
 
 /**
  * [RowScope] [SDGGhostButton]
@@ -26,7 +25,6 @@ fun RowScope.SDGGhostButton(
     labelColor: Color,
     onClick: () -> Unit,
     enable: Boolean = true,
-    labelTypeface: IOTypeface = IOTypeface.REGULAR,
     @DrawableRes leftIcon: Int? = null,
     leftIconTint: Color? = null,
     @DrawableRes rightIcon: Int? = null,
@@ -40,7 +38,6 @@ fun RowScope.SDGGhostButton(
             size = size,
             label = label,
             labelColor = labelColor,
-            labelTypeface = labelTypeface,
             leftIcon = leftIcon,
             leftIconTint = leftIconTint,
             rightIcon = rightIcon,
@@ -63,7 +60,6 @@ fun BoxScope.SDGGhostButton(
     labelColor: Color,
     onClick: () -> Unit,
     enable: Boolean = true,
-    labelTypeface: IOTypeface = IOTypeface.REGULAR,
     @DrawableRes leftIcon: Int? = null,
     leftIconTint: Color? = null,
     @DrawableRes rightIcon: Int? = null,
@@ -77,7 +73,6 @@ fun BoxScope.SDGGhostButton(
             size = size,
             label = label,
             labelColor = labelColor,
-            labelTypeface = labelTypeface,
             leftIcon = leftIcon,
             leftIconTint = leftIconTint,
             rightIcon = rightIcon,

--- a/sdg/src/main/java/com/shopl/sdg/component/util/button/ghost/SDGGhostButton.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/util/button/ghost/SDGGhostButton.kt
@@ -1,0 +1,150 @@
+package com.shopl.sdg.component.util.button.ghost
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import com.shopl.sdg.component.button.ghost.SDGGhostButton
+import com.shopl.sdg.component.button.ghost.SDGGhostButtonSize
+import com.shopl.sdg_common.ui.components.IOTypeface
+
+/**
+ * [RowScope] [SDGGhostButton]
+ */
+@Composable
+fun RowScope.SDGGhostButton(
+    weight: Float,
+    size: SDGGhostButtonSize,
+    label: String,
+    labelColor: Color,
+    onClick: () -> Unit,
+    enable: Boolean = true,
+    labelTypeface: IOTypeface = IOTypeface.REGULAR,
+    @DrawableRes leftIcon: Int? = null,
+    leftIconTint: Color? = null,
+    @DrawableRes rightIcon: Int? = null,
+    rightIconTint: Color? = null,
+    marginValues: PaddingValues = PaddingValues(),
+) {
+    Box(Modifier.weight(weight)) {
+        SDGGhostButton(
+            isFillMaxWidth = true,
+            enable = enable,
+            size = size,
+            label = label,
+            labelColor = labelColor,
+            labelTypeface = labelTypeface,
+            leftIcon = leftIcon,
+            leftIconTint = leftIconTint,
+            rightIcon = rightIcon,
+            rightIconTint = rightIconTint,
+            marginValues = marginValues,
+            onClick = onClick,
+        )
+    }
+}
+
+/**
+ * [BoxScope] [SDGGhostButton]
+ */
+@Composable
+fun BoxScope.SDGGhostButton(
+    alignment: Alignment,
+    isFillMaxWidth: Boolean,
+    size: SDGGhostButtonSize,
+    label: String,
+    labelColor: Color,
+    onClick: () -> Unit,
+    enable: Boolean = true,
+    labelTypeface: IOTypeface = IOTypeface.REGULAR,
+    @DrawableRes leftIcon: Int? = null,
+    leftIconTint: Color? = null,
+    @DrawableRes rightIcon: Int? = null,
+    rightIconTint: Color? = null,
+    marginValues: PaddingValues = PaddingValues(),
+) {
+    Box(Modifier.align(alignment)) {
+        SDGGhostButton(
+            isFillMaxWidth = isFillMaxWidth,
+            enable = enable,
+            size = size,
+            label = label,
+            labelColor = labelColor,
+            labelTypeface = labelTypeface,
+            leftIcon = leftIcon,
+            leftIconTint = leftIconTint,
+            rightIcon = rightIcon,
+            rightIconTint = rightIconTint,
+            marginValues = marginValues,
+            onClick = onClick,
+        )
+    }
+}
+
+
+@Preview
+@Composable
+private fun PreviewRowScopeSDGGhostButton() {
+    Row {
+        SDGGhostButton(
+            weight = 1f,
+            size = SDGGhostButtonSize.Medium,
+            label = "Ghost Button",
+            labelColor = Color.Black,
+            onClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewRowScopeSDGGhostButtonWithIcon() {
+    Row {
+        SDGGhostButton(
+            weight = 1f,
+            size = SDGGhostButtonSize.Medium,
+            label = "Ghost Button",
+            labelColor = Color.Black,
+            onClick = {},
+            leftIcon = android.R.drawable.ic_dialog_email
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBoxScopeSDGGhostButton() {
+    Box {
+        SDGGhostButton(
+            alignment = Alignment.Center,
+            isFillMaxWidth = true,
+            size = SDGGhostButtonSize.Medium,
+            label = "Ghost Button",
+            labelColor = Color.Black,
+            onClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBoxScopeSDGGhostButtonWithIcon() {
+    Box {
+        SDGGhostButton(
+            alignment = Alignment.Center,
+            isFillMaxWidth = true,
+            size = SDGGhostButtonSize.Medium,
+            label = "Ghost Button",
+            labelColor = Color.Black,
+            onClick = {},
+            leftIcon = android.R.drawable.ic_dialog_email
+        )
+    }
+}

--- a/sdg/src/main/java/com/shopl/sdg/template/multi_calendar/SDGMultiCalendar.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/multi_calendar/SDGMultiCalendar.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.shopl.sdg.component.button.ghost.SDGGhostButton
 import com.shopl.sdg.component.button.ghost.SDGGhostButtonSize
 import com.shopl.sdg.component.calendar.SDGCalendarDay
 import com.shopl.sdg.component.calendar.SDGCalendarDayMode
@@ -46,6 +45,7 @@ import com.shopl.sdg.component.calendar.WeekDateTime
 import com.shopl.sdg.component.calendar.equalY
 import com.shopl.sdg.component.calendar.equalYM
 import com.shopl.sdg.component.tab.SDGLineFixedTab
+import com.shopl.sdg.component.util.button.ghost.SDGGhostButton
 import com.shopl.sdg_common.ext.distanceDays
 import com.shopl.sdg_common.ext.withColor
 import com.shopl.sdg_common.foundation.SDGColor
@@ -317,7 +317,6 @@ fun SDGMultiCalendarModal(
                     size = SDGGhostButtonSize.Large,
                     label = stringResource(id = R.string.dialog_common_btn_ok),
                     labelColor = SDGColor.Neutral700,
-                    labelTypeface = IOTypeface.SEMI_BOLD,
                     onClick = {
                         when (val type = types[selectedTabIndex]) {
                             is SDGMultiCalendarModalType.Day -> {


### PR DESCRIPTION
## JIRA
[SH-12090](https://shoplworks.atlassian.net/browse/SH-12090)

## 작업사항
- `Component > Ghost Button` 내 `IOText` 및 `IOImage`를 `SDG`로 교체
- `labelTypeface` 제거
- `SDGGhostButtonSize` 내 `label size`를 `SDGTypography`로 교체
- `Row, Box Scope` 확장 컴포저블 파일 분리
- 컨벤션에 맞게 주석 추가
- `Multi Calander` 내 `Ghost Button` 수정

## 리뷰 요청 및 특이사항
- 기존 사용하고 있던 `Multi Calander` 내 `R.string.dialog_common_btn_ok`에 대한 `Ghost Button`에 `labelTypeface`가 Bold로 적용되어 있었는데, 피그마 보시면 `SDGTypography`에 맞게 수정되어 있습니다. 참고 부탁드립니다.
- [피그마](https://www.figma.com/design/qWVshatQ9eqoIn4fdEZqWy/SDG?node-id=8099-26621&m=dev)
  - Type -> 일별 -> '확인' 버튼


[SH-12090]: https://shoplworks.atlassian.net/browse/SH-12090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ