### PR TITLE
[SH-12920] [Android] Template > Profile > Second Profile 리네임 및 일부 요소 변경 대응

### DIFF
--- a/sdg/src/main/java/com/shopl/sdg/template/profile/second/SDGSecondProfile.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/profile/second/SDGSecondProfile.kt
@@ -1,0 +1,126 @@
+package com.shopl.sdg.template.profile.second
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.shopl.sdg.component.avatar.SDGAvatar
+import com.shopl.sdg.component.avatar.SDGAvatarBadge
+import com.shopl.sdg.component.avatar.SDGAvatarSize
+import com.shopl.sdg_common.ext.clickable
+import com.shopl.sdg_common.foundation.SDGColor
+import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing8
+import com.shopl.sdg_common.ui.components.SDGText
+
+/**
+ * SDG - Profile - Second Profile
+ *
+ * 직원, 작성자 등 사람의 사진과 정보를 보여주는 컴포넌트
+ * avatar S(size 30)을 기준으로 이름과 서브정보를 표시하는 컴포넌트
+ *
+ * @see <a href="https://www.figma.com/design/qWVshatQ9eqoIn4fdEZqWy/SDG?node-id=6840-15005&m=dev">Figma</a>
+ */
+@Composable
+fun SDGSecondProfile(
+    userRegImg: String?,
+    userName: String?,
+    groupName: String?,
+    backgroundColor: Color,
+    type: SDGSecondProfileType,
+    avatarBadge: SDGAvatarBadge,
+    isMultiLine: Boolean = false,
+    isMaternity: Boolean = false,
+    radius: Dp? = null,
+    paddingValues: PaddingValues = PaddingValues(),
+    activate: Boolean = true,
+    onClickAvatar: (() -> Unit)? = null,
+    onClickProfile: (() -> Unit)? = null
+) {
+
+    val profileModifier = Modifier
+        .fillMaxWidth()
+        .then(
+            if (!activate) Modifier.alpha(0.6F) else Modifier
+        )
+        .then(
+            if (onClickProfile != null) {
+                Modifier.clickable(hasRipple = false) { onClickProfile() }
+            } else {
+                Modifier
+            }
+        )
+        .background(
+            color = backgroundColor,
+            shape = RoundedCornerShape(radius ?: 0.dp)
+        )
+        .clip(RoundedCornerShape(radius ?: 0.dp))
+        .padding(paddingValues)
+
+    Row(
+        modifier = profileModifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = spacedBy(Spacing8)
+    ) {
+        SDGAvatar(
+            avatarSize = SDGAvatarSize.S,
+            avatarBadge = avatarBadge,
+            userRegImg = userRegImg,
+            onClickAvatar = onClickAvatar,
+            isMaternity = isMaternity,
+        )
+
+        Column(
+            modifier = Modifier
+        ) {
+            userName?.let {
+                SDGText(
+                    text = it,
+                    typography = type.userNameTypography,
+                    textColor = type.userNameColor,
+                    maxLines = if (isMultiLine) Int.MAX_VALUE else 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            groupName?.let {
+                SDGText(
+                    text = it,
+                    typography = type.groupNameTypography,
+                    textColor = type.groupNameColor,
+                    maxLines = if (isMultiLine) Int.MAX_VALUE else 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSDGSecondProfile() {
+    SDGSecondProfile(
+        userRegImg = null,
+        userName = "김사플",
+        groupName = "Design Team",
+        backgroundColor = SDGColor.Neutral0,
+        type = SDGSecondProfileType.Normal,
+        avatarBadge = SDGAvatarBadge.Admin,
+    )
+}
+
+
+

--- a/sdg/src/main/java/com/shopl/sdg/template/profile/second/SDGSecondProfile.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/profile/second/SDGSecondProfile.kt
@@ -121,6 +121,3 @@ private fun PreviewSDGSecondProfile() {
         avatarBadge = SDGAvatarBadge.Admin,
     )
 }
-
-
-

--- a/sdg/src/main/java/com/shopl/sdg/template/profile/second/SDGSecondProfile.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/profile/second/SDGSecondProfile.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.shopl.sdg.component.avatar.SDGAvatar
 import com.shopl.sdg.component.avatar.SDGAvatarBadge
 import com.shopl.sdg.component.avatar.SDGAvatarSize
@@ -63,11 +62,16 @@ fun SDGSecondProfile(
                 Modifier
             }
         )
+        .then(
+            if (radius != null) {
+                Modifier.clip(RoundedCornerShape(radius))
+            } else {
+                Modifier
+            }
+        )
         .background(
             color = backgroundColor,
-            shape = RoundedCornerShape(radius ?: 0.dp)
         )
-        .clip(RoundedCornerShape(radius ?: 0.dp))
         .padding(paddingValues)
 
     Row(

--- a/sdg/src/main/java/com/shopl/sdg/template/profile/second/SDGSecondProfileType.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/profile/second/SDGSecondProfileType.kt
@@ -1,0 +1,25 @@
+package com.shopl.sdg.template.profile.second
+
+import androidx.compose.ui.graphics.Color
+import com.shopl.sdg_common.foundation.SDGColor
+import com.shopl.sdg_common.foundation.typography.SDGTypography
+
+enum class SDGSecondProfileType(
+    val userNameTypography: SDGTypography,
+    val groupNameTypography: SDGTypography,
+    val userNameColor: Color,
+    val groupNameColor: Color
+) {
+    Normal(
+        userNameTypography = SDGTypography.Body2R,
+        groupNameTypography = SDGTypography.Body3R,
+        userNameColor = SDGColor.Neutral700,
+        groupNameColor = SDGColor.Neutral500
+    ),
+    Empha(
+        userNameTypography = SDGTypography.Body2SB,
+        groupNameTypography = SDGTypography.Body3R,
+        userNameColor = SDGColor.Neutral700,
+        groupNameColor = SDGColor.Neutral700
+    ),
+}


### PR DESCRIPTION
## JIRA
[SH-12920](https://shoplworks.atlassian.net/browse/SH-12920)

## 작업사항
- `Second Profile` 변경사항 대응
  - `Profile Second` -> `Second Profile`
  - 일부 디자인 요소 변경

## 리뷰 요청 및 특이사항
기존에 있는 Profile Second는 Template - History에서 사용중인데, History가 디자인팀에서 작업이 완료되지 않아
제거 및 교체 적용하지 않았습니다.
추후 History 디자인 작업이 완료되면 교체하면 될 것 같습니다.


[SH-12920]: https://shoplworks.atlassian.net/browse/SH-12920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ