### PR TITLE
[SH-12960] [Android] SDG Template > Simple Text Form - 숫자만 사용하는 경우 키보드 타입 수정

### DIFF
--- a/sdg/src/main/java/com/shopl/sdg/template/util/simple_input_form/SDGSimpleInputForm.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/util/simple_input_form/SDGSimpleInputForm.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,6 +23,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -136,7 +139,11 @@ fun SDGSimpleInputForm(
             onInputChange = onValueChange,
             decimalFormat = decimalFormat,
             minValue = minValue,
-            maxValue = maxValue
+            maxValue = maxValue,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                imeAction = ImeAction.Done,
+                keyboardType = KeyboardType.Number
+            )
         )
     }
 }


### PR DESCRIPTION
## JIRA
[SH-12960](https://shoplworks.atlassian.net/browse/SH-12960)

## 작업사항
- SDGSimpleInputForm > keyboardOptions 수정
- 수정된 SDGSimpleInputForm은 util 하위의 decimalFormat을 파라미터로 받는 Form입니다.
- 따라서 keyboardOptions을 파라미터로 전달받지 않고, 내부 고정하였습니다.

## 리뷰 요청 및 특이사항
- 리뷰어에게 요청이나, 특이사항을 작성해주세요. 없다면 생략해도 괜찮습니다.


[SH-12960]: https://shoplworks.atlassian.net/browse/SH-12960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ