### PR TITLE
[SH-12986] [Android] Center Popup Max Height 기준 수정 (화면의 60px 띄고 -> 화면의 80px 띄고)

### DIFF
--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
@@ -6,13 +6,16 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -55,9 +58,14 @@ fun SDGCenterPopup(
     ) {
         (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.4f)
 
+        val containerSize = LocalWindowInfo.current.containerSize
+        val density = LocalDensity.current.density
+        val screenHeight = containerSize.height.dp / density
+
         Column(
             modifier = Modifier
                 .padding(horizontal = SDGSpacing.Spacing20)
+                .heightIn(max = screenHeight - 160.dp)
                 .background(
                     color = SDGColor.Neutral0,
                     shape = RoundedCornerShape(SDGCornerRadius.Radius20)
@@ -161,7 +169,7 @@ private fun PreviewSDGCenterPopupDeleteOption() {
         ),
         title = "팝업 타이틀",
         body = {
-            repeat(40){
+            repeat(40) {
                 SDGText(
                     text = "팝업 내용입니다. ",
                     typography = SDGTypography.Body1R,

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
@@ -35,6 +35,8 @@ import com.shopl.sdg_common.ui.components.SDGText
  *
  * @see <a href="https://www.figma.com/design/qWVshatQ9eqoIn4fdEZqWy/SDG?node-id=19174-17196&t=dilCeVYD7pIRNnAx-4">Figma</a>
  */
+private const val DIALOG_DIM_AMOUNT = 0.4f
+
 @Composable
 fun SDGCenterPopup(
     buttonOption: SDGCenterPopupButtonOption,
@@ -56,7 +58,7 @@ fun SDGCenterPopup(
             usePlatformDefaultWidth = false
         )
     ) {
-        (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.4f)
+        (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(DIALOG_DIM_AMOUNT)
 
         val containerSize = LocalWindowInfo.current.containerSize
         val density = LocalDensity.current.density

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/confirm/SDGConfirmCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/confirm/SDGConfirmCenterPopup.kt
@@ -19,7 +19,7 @@ import com.shopl.sdg_common.ui.components.SDGText
  */
 @Composable
 fun SDGConfirmCenterPopup(
-    title: String,
+    title: String?,
     description: String,
     confirmLabel: String,
     onClickConfirm: () -> Unit,

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/delete/SDGDeleteCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/delete/SDGDeleteCenterPopup.kt
@@ -19,7 +19,7 @@ import com.shopl.sdg_common.ui.components.SDGText
  */
 @Composable
 fun SDGDeleteCenterPopup(
-    title: String,
+    title: String?,
     description: String,
     cancelLabel: String,
     onClickCancel: () -> Unit,

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/info/SDGInfoCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/info/SDGInfoCenterPopup.kt
@@ -19,7 +19,7 @@ import com.shopl.sdg_common.ui.components.SDGText
  */
 @Composable
 fun SDGInfoCenterPopup(
-    title: String,
+    title: String?,
     description: String,
     confirmLabel: String,
     onClickConfirm: () -> Unit,

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/input/SDGInputCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/input/SDGInputCenterPopup.kt
@@ -31,7 +31,7 @@ import com.shopl.sdg_common.ui.components.SDGText
  */
 @Composable
 fun SDGInputCenterPopup(
-    title: String,
+    title: String?,
     description: String,
     confirmLabel: String,
     onClickConfirm: () -> Unit,


### PR DESCRIPTION
## JIRA
[SH-12986](https://shoplworks.atlassian.net/browse/SH-12986)

## 작업사항
- Center Popup Max Height 기준을 화면 상하 80 여백으로 수정
- 디자인 가이드에 맞춰 title을 nullable로 수정


[SH-12986]: https://shoplworks.atlassian.net/browse/SH-12986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ