### PR TITLE
[SH-13286] Clickable hasRipple default 값을 false로 변경

### DIFF
--- a/sdg-common/src/main/java/com/shopl/sdg_common/ext/ModifierExt.kt
+++ b/sdg-common/src/main/java/com/shopl/sdg_common/ext/ModifierExt.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 fun Modifier.clickable(
-    hasRipple: Boolean = true,
+    hasRipple: Boolean = false,
     rippleColor: Color = SDGColor.Neutral900_a10,
     enabled: Boolean = true,
     onClickLabel: String? = null,


### PR DESCRIPTION
## JIRA
[SH-13286](https://shoplworks.atlassian.net/browse/SH-13286)

## 작업사항
- `clickable` 사용성 개선을 위한 `hasRipple`의 `default value`를 `true`에서 `false`로 변경

## 리뷰 요청 및 특이사항
`clickable`를 사용하는 기존 컴포넌트 사이드 이펙트를 염려하여 확인했는데 이상 없을 것으로 판단됩니다.
- 기존`hasRipple`의 `default value`가 `true`였으므로 아래와 같이 사용하는 코드 존재 시 문제가 발생할 수 있음
```
// 리플 효과가 보여야함
Modifier.clicakble(rippleColor = SDGColor.Primary300)
```
- `ripple`이 필요한 사용처에서는 `argument`를 `true`로 직접 넣어서 사용 중

[SH-13286]: https://shoplworks.atlassian.net/browse/SH-13286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ