### PR TITLE
[SH-13477] SDGAsyncImage LocalInspectionMode 추가

### DIFF
--- a/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGAsyncImage.kt
+++ b/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGAsyncImage.kt
@@ -41,12 +41,15 @@ fun SDGAsyncImage(
     filterQuality: FilterQuality = DefaultFilterQuality,
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
-) {
-    if (LocalInspectionMode.current) {
+    previewContent: (@Composable (() -> Unit)) = {
         SDGImage(
-            resId = R.drawable.avatar_empty,
+            resId = R.drawable.ic_common_photo,
             color = SDGColor.Neutral0,
         )
+    },
+) {
+    if (LocalInspectionMode.current) {
+        previewContent()
 
         return
     }
@@ -95,12 +98,15 @@ fun SDGAsyncImage(
     filterQuality: FilterQuality = DefaultFilterQuality,
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
-) {
-    if (LocalInspectionMode.current) {
+    previewContent: (@Composable (() -> Unit)) = {
         SDGImage(
-            resId = R.drawable.avatar_empty,
+            resId = R.drawable.ic_common_photo,
             color = SDGColor.Neutral0,
         )
+    },
+) {
+    if (LocalInspectionMode.current) {
+        previewContent()
 
         return
     }

--- a/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGAsyncImage.kt
+++ b/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGAsyncImage.kt
@@ -137,22 +137,3 @@ private fun SDGAsyncImagePreview() {
         imageModel = "imageUrl",
     )
 }
-
-@Preview(
-    name = "SDGAsyncImage Failure Composable Preview",
-    showBackground = true,
-    backgroundColor = 0xFFF0F0F0
-)
-@Composable
-private fun SDGAsyncImageFailurePreview() {
-    SDGAsyncImage(
-        modifier = Modifier.size(64.dp),
-        imageModel = null,
-        failureImage = {
-            SDGImage(
-                resId = R.drawable.avatar_empty,
-                color = SDGColor.Primary300
-            )
-        },
-    )
-}

--- a/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGAsyncImage.kt
+++ b/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGAsyncImage.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.drawscope.DrawScope.Companion.DefaultFilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
@@ -41,6 +42,15 @@ fun SDGAsyncImage(
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
 ) {
+    if (LocalInspectionMode.current) {
+        SDGImage(
+            resId = R.drawable.avatar_empty,
+            color = SDGColor.Neutral0,
+        )
+
+        return
+    }
+
     SubcomposeAsyncImage(
         model = imageModel,
         contentDescription = contentDescription,
@@ -86,6 +96,15 @@ fun SDGAsyncImage(
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
 ) {
+    if (LocalInspectionMode.current) {
+        SDGImage(
+            resId = R.drawable.avatar_empty,
+            color = SDGColor.Neutral0,
+        )
+
+        return
+    }
+
     SubcomposeAsyncImage(
         model = imageModel,
         contentDescription = contentDescription,
@@ -116,7 +135,6 @@ private fun SDGAsyncImagePreview() {
     SDGAsyncImage(
         modifier = Modifier.size(64.dp),
         imageModel = "imageUrl",
-        failureImageResourceId = R.drawable.avatar_empty,
     )
 }
 


### PR DESCRIPTION
## JIRA
[SH-13477](https://shoplworks.atlassian.net/browse/SH-13477)

## 작업사항
- SDGAsynceImage에 LocalInspectionMode에 따른 Preview 기본 이미지 추가

## 리뷰 요청 및 특이사항
- 현재 구현으론 `SDGAsyncImageFailurePreview` 프리뷰를 확인할 수 없습니다.
- failureImage는 단독 Composable이므로 SDGAsyncImage가 failureImage에 대한 프리뷰를 제공할 필요는 없다고 생각하는데, 제거하는건 어떠신가요?

[SH-13477]: https://shoplworks.atlassian.net/browse/SH-13477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ