### PR TITLE
[SH-18856] [Android] SDG Template > Popup > Bottom Popup - Body 영역 가변 크기 시 하단 버튼 위치 변경되는 문제 수정

### DIFF
--- a/sdg/src/main/java/com/shopl/sdg/template/popup/bottom/SDGBottomPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/bottom/SDGBottomPopup.kt
@@ -1,6 +1,5 @@
 package com.shopl.sdg.template.popup.bottom
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -72,36 +71,39 @@ fun SDGBottomPopup(
         scrimColor = SDGColor.Neutral900_a40,
         dragHandle = null,
     ) {
+        val bodyTopPadding = if (title.isNullOrBlank()) Spacing24 else Spacing12
+
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(max = maxSheetHeight)
         ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(space = Spacing12),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = Spacing24, start = Spacing24, end = Spacing24)
-            ) {
-                if (!title.isNullOrBlank()) {
-                    SDGText(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = title,
-                        typography = SDGTypography.Title2SB,
-                        textColor = SDGColor.Neutral700,
-                        textAlign = titleAlignment,
-                    )
-                }
-
-                Column(
+            if (!title.isNullOrBlank()) {
+                SDGText(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(weight = 1f, fill = false)
-                        .verticalScroll(state = rememberScrollState())
-                        .padding(top = Spacing4, bottom = Spacing28)
-                ) {
-                    body()
-                }
+                        .padding(top = Spacing24, start = Spacing24, end = Spacing24),
+                    text = title,
+                    typography = SDGTypography.Title2SB,
+                    textColor = SDGColor.Neutral700,
+                    textAlign = titleAlignment,
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(weight = 1f, fill = false)
+                    .padding(top = bodyTopPadding)
+                    .verticalScroll(state = rememberScrollState())
+                    .padding(
+                        top = Spacing4,
+                        start = Spacing24,
+                        end = Spacing24,
+                        bottom = Spacing28,
+                    )
+            ) {
+                body()
             }
 
             SDGBottomPopupButton(option = buttonOption)


### PR DESCRIPTION
## JIRA
[SH-18856](https://shoplworks.atlassian.net/browse/SH-18856)

## 작업사항
- SDGBottomPopup Body 영역에 가변 크기 Content 존재하는 경우 하단 버튼 밀려나는 문제 수정
<img width="300" height="800" alt="image" src="https://github.com/user-attachments/assets/1925cd0b-67e7-4028-972e-999288034a36" />
<img width="300" height="800" alt="image" src="https://github.com/user-attachments/assets/50cc1d7f-ccf5-4453-97d5-700543fce765" />


## 리뷰 요청 및 특이사항
- 리뷰어에게 요청이나, 특이사항을 작성해주세요. 없다면 생략해도 괜찮습니다.


[SH-18856]: https://shoplworks.atlassian.net/browse/SH-18856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ