### PR TITLE
[SH-20673] [Android] Simple Text Input 숫자만 입력 시 소수점 + 0 입력 동작 안되는 문제 수정

### DIFF
--- a/sdg/src/main/java/com/shopl/sdg/component/util/simple_text_input/SDGSimpleTextInput.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/util/simple_text_input/SDGSimpleTextInput.kt
@@ -225,6 +225,8 @@ fun SDGSimpleTextInput(
     maxValue: Double? = null,
 ) {
     var isFocused by remember { mutableStateOf(false) }
+    val minBigDecimal = remember(minValue) { minValue?.toBigDecimal() }
+    val maxBigDecimal = remember(maxValue) { maxValue?.toBigDecimal() }
 
     val inputBgColor = when (inputState) {
         InputState.Disable,
@@ -330,8 +332,8 @@ fun SDGSimpleTextInput(
                             return@onSuccess
                         }
 
-                        val isInRange = (minValue == null || parsedBigDecimal >= minValue.toBigDecimal()) &&
-                                (maxValue == null || parsedBigDecimal <= maxValue.toBigDecimal())
+                        val isInRange = (minBigDecimal == null || parsedBigDecimal >= minBigDecimal) &&
+                                (maxBigDecimal == null || parsedBigDecimal <= maxBigDecimal)
 
                         if (isInRange) {
                             onInputChange(

--- a/sdg/src/main/java/com/shopl/sdg/component/util/simple_text_input/SDGSimpleTextInput.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/util/simple_text_input/SDGSimpleTextInput.kt
@@ -248,10 +248,11 @@ fun SDGSimpleTextInput(
 
     val displayValue = decimalFormat?.let { formatter ->
         val numberValue = input.text.toBigDecimalOrNull()
-        if (numberValue == null ||
-            (input.text.endsWith(formatter.decimalFormatSymbols.decimalSeparator)
-                    && input.text.count { it == formatter.decimalFormatSymbols.decimalSeparator } == 1)
-        ) {
+        val shouldKeepInput = numberValue == null ||
+                input.text.isTypingDecimalSeparator(formatter) ||
+                input.text.shouldKeepFractionInput(formatter)
+
+        if (shouldKeepInput) {
             input
         } else {
             val originValueLength = input.text.length
@@ -325,16 +326,14 @@ fun SDGSimpleTextInput(
                             value.selection
                         }
 
-                        if (minValue != null && maxValue != null) {
-                            if (parsedBigDecimal != null && parsedBigDecimal in minValue.toBigDecimal()..maxValue.toBigDecimal()) {
-                                onInputChange(
-                                    value.copy(
-                                        text = cleanText,
-                                        selection = selection,
-                                    )
-                                )
-                            }
-                        } else {
+                        if (parsedBigDecimal == null) {
+                            return@onSuccess
+                        }
+
+                        val isInRange = (minValue == null || parsedBigDecimal >= minValue.toBigDecimal()) &&
+                                (maxValue == null || parsedBigDecimal <= maxValue.toBigDecimal())
+
+                        if (isInRange) {
                             onInputChange(
                                 value.copy(
                                     text = cleanText,
@@ -439,6 +438,21 @@ fun SDGSimpleTextInput(
     )
 }
 
+private fun String.isTypingDecimalSeparator(formatter: DecimalFormat): Boolean {
+    val decimalSeparator = formatter.decimalFormatSymbols.decimalSeparator
+    return endsWith(decimalSeparator) && count { it == decimalSeparator } == 1
+}
+
+private fun String.shouldKeepFractionInput(formatter: DecimalFormat): Boolean {
+    val decimalSeparator = formatter.decimalFormatSymbols.decimalSeparator
+    if (formatter.maximumFractionDigits <= 0 || !contains(decimalSeparator)) return false
+
+    val fraction = substringAfter(decimalSeparator)
+    return fraction.isNotEmpty() &&
+            fraction.length <= formatter.maximumFractionDigits &&
+            fraction.last() == '0'
+}
+
 @Preview
 @Composable
 private fun PreviewSDGSimpleTextInput() {
@@ -460,10 +474,10 @@ private fun PreviewSDGSimpleTextInput() {
             input = numberInput,
             hint = "금액을 입력하세요",
             inputState = InputState.Enable,
-            decimalFormat = DecimalFormat("#,###"),
-            minValue = 1000.0,
-            maxValue = 1000000.0,
-            onInputChange = { numberInput = it }
+            decimalFormat = DecimalFormat("###,###.###"),
+            maxValue = 100000.0,
+            onInputChange = { numberInput = it },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         )
     }
 }


### PR DESCRIPTION
## JIRA
[SH-20673](https://shoplworks.atlassian.net/browse/SH-20673)

## 작업사항
- 숫자 입력 전용 SDGSimpleTextInput에서 소수점 입력 시 XXX.0XX 입력 불가능한 문제가 발견되어 수정하였습니다.
- maxValue, minValue 하나의 값만 있더라도 동작하도록 수정하였습니다. (이전에는 둘 다 있어야지만 동작)

## 리뷰 요청 및 특이사항
- 리뷰어에게 요청이나, 특이사항을 작성해주세요. 없다면 생략해도 괜찮습니다.


[SH-20673]: https://shoplworks.atlassian.net/browse/SH-20673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ