### PR TITLE
[SH-21248] 팝업 preview 렌더링 지원

### DIFF
--- a/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGModalBottomSheet.kt
+++ b/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGModalBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.shopl.sdg_common.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,10 +11,13 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import com.shopl.sdg_common.foundation.SDGColor
+import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -25,6 +29,15 @@ fun SDGModalBottomSheet(
     contentColor: Color = SDGColor.Neutral0,
     content: @Composable() (ColumnScope.() -> Unit),
 ) {
+    if (LocalInspectionMode.current) {
+        SDGModalBottomSheetInspectionPreview(
+            modifier = modifier,
+            containerColor = containerColor,
+            content = content,
+        )
+        return
+    }
+
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
@@ -35,12 +48,44 @@ fun SDGModalBottomSheet(
         scrimColor = SDGColor.Neutral900_a40,
         dragHandle = null,
     ) {
-        Column(
+        SDGModalBottomSheetContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding(),
-        ) {
-            content()
-        }
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun SDGModalBottomSheetContent(
+    modifier: Modifier,
+    content: @Composable() (ColumnScope.() -> Unit),
+) {
+    Column(modifier = modifier) {
+        content()
+    }
+}
+
+/**
+ * Compose Preview에서 ModalBottomSheet 대신 Bottom Sheet 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGModalBottomSheetInspectionPreview(
+    modifier: Modifier,
+    containerColor: Color,
+    content: @Composable() (ColumnScope.() -> Unit),
+) {
+    SDGPopupPreviewContainer(contentAlignment = Alignment.BottomCenter) {
+        SDGModalBottomSheetContent(
+            modifier = modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .background(
+                    color = containerColor,
+                    shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+                ),
+            content = content,
+        )
     }
 }

--- a/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGModalBottomSheet.kt
+++ b/sdg-common/src/main/java/com/shopl/sdg_common/ui/components/SDGModalBottomSheet.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.unit.dp
+import com.shopl.sdg_common.foundation.SDGCornerRadius
 import com.shopl.sdg_common.foundation.SDGColor
 import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 
@@ -42,7 +42,10 @@ fun SDGModalBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
         sheetState = sheetState,
-        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+        shape = RoundedCornerShape(
+            topStart = SDGCornerRadius.Radius20,
+            topEnd = SDGCornerRadius.Radius20
+        ),
         containerColor = containerColor,
         contentColor = contentColor,
         scrimColor = SDGColor.Neutral900_a40,
@@ -83,7 +86,10 @@ private fun SDGModalBottomSheetInspectionPreview(
                 .navigationBarsPadding()
                 .background(
                     color = containerColor,
-                    shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+                    shape = RoundedCornerShape(
+                        topStart = SDGCornerRadius.Radius20,
+                        topEnd = SDGCornerRadius.Radius20
+                    )
                 ),
             content = content,
         )

--- a/sdg-common/src/main/java/com/shopl/sdg_common/util/SDGPopupPreviewContainer.kt
+++ b/sdg-common/src/main/java/com/shopl/sdg_common/util/SDGPopupPreviewContainer.kt
@@ -20,15 +20,15 @@ import com.shopl.sdg_common.foundation.typography.SDGTypography
 import com.shopl.sdg_common.ui.components.SDGText
 
 /**
- * Compose Preview에서 팝업 콘텐츠를 인라인으로 렌더링하기 위한 host입니다.
+ * Compose Preview에서 팝업 콘텐츠를 인라인으로 렌더링하기 위한 container입니다.
  *
  * Preview에서는 [androidx.compose.ui.window.Dialog]나
  * Material BottomSheet가 별도 window/sheet로 표시되지 않아 콘텐츠를 확인하기 어렵습니다.
- * 이 host는 preview 전용 fallback으로 dim 배경과 정렬 위치만 제공하고,
+ * 이 container는 preview 전용 fallback으로 dim 배경과 정렬 위치만 제공하고,
  * 실제 팝업의 runtime window 동작은 대체하지 않습니다.
  */
 @Composable
-fun SDGPopupPreviewHost(
+fun SDGPopupPreviewContainer(
     contentAlignment: Alignment,
     modifier: Modifier = Modifier,
     withDim: Boolean = true,
@@ -51,8 +51,8 @@ fun SDGPopupPreviewHost(
 
 @Preview(name = "SDGModalBottomSheet", widthDp = 360, heightDp = 640)
 @Composable
-private fun PreviewSDGPopupPreviewHost() {
-    SDGPopupPreviewHost(contentAlignment = Alignment.BottomCenter) {
+private fun PreviewSDGPopupPreviewContainer() {
+    SDGPopupPreviewContainer(contentAlignment = Alignment.BottomCenter) {
         val items = listOf(1, 2, 3, 4, 5)
         Column(
             modifier = Modifier

--- a/sdg-common/src/main/java/com/shopl/sdg_common/util/SDGPopupPreviewHost.kt
+++ b/sdg-common/src/main/java/com/shopl/sdg_common/util/SDGPopupPreviewHost.kt
@@ -1,0 +1,81 @@
+package com.shopl.sdg_common.util
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.shopl.sdg_common.foundation.SDGColor
+import com.shopl.sdg_common.foundation.SDGCornerRadius
+import com.shopl.sdg_common.foundation.typography.SDGTypography
+import com.shopl.sdg_common.ui.components.SDGText
+
+/**
+ * Compose Preview에서 팝업 콘텐츠를 인라인으로 렌더링하기 위한 host입니다.
+ *
+ * Preview에서는 [androidx.compose.ui.window.Dialog]나
+ * Material BottomSheet가 별도 window/sheet로 표시되지 않아 콘텐츠를 확인하기 어렵습니다.
+ * 이 host는 preview 전용 fallback으로 dim 배경과 정렬 위치만 제공하고,
+ * 실제 팝업의 runtime window 동작은 대체하지 않습니다.
+ */
+@Composable
+fun SDGPopupPreviewHost(
+    contentAlignment: Alignment,
+    modifier: Modifier = Modifier,
+    withDim: Boolean = true,
+    scrimColor: Color = SDGColor.Neutral900_a40,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = if (withDim) {
+            modifier
+                .fillMaxSize()
+                .background(scrimColor)
+        } else {
+            modifier
+        },
+        contentAlignment = contentAlignment
+    ) {
+        content()
+    }
+}
+
+@Preview(name = "SDGModalBottomSheet", widthDp = 360, heightDp = 640)
+@Composable
+private fun PreviewSDGPopupPreviewHost() {
+    SDGPopupPreviewHost(contentAlignment = Alignment.BottomCenter) {
+        val items = listOf(1, 2, 3, 4, 5)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = SDGColor.Neutral0,
+                    shape = RoundedCornerShape(
+                        topStart = SDGCornerRadius.Radius20,
+                        topEnd = SDGCornerRadius.Radius20
+                    )
+                )
+                .navigationBarsPadding()
+        ) {
+            items.forEach {
+                SDGText(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 16.dp),
+                    text = "Item $it",
+                    typography = SDGTypography.Body1R,
+                    textColor = SDGColor.Neutral700
+                )
+            }
+        }
+    }
+}

--- a/sdg/src/main/java/com/shopl/sdg/component/progress/SDGSystemProgress.kt
+++ b/sdg/src/main/java/com/shopl/sdg/component/progress/SDGSystemProgress.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -46,23 +47,41 @@ fun SDGSystemProgress(
 
 @Composable
 fun SDGSystemProgressPopup() {
+    if (LocalInspectionMode.current) {
+        SDGSystemProgressPopupInspectionPreview()
+        return
+    }
+
     Dialog(
         onDismissRequest = { },
         DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
     ) {
         (LocalView.current.parent as? DialogWindowProvider)?.window?.setDimAmount(0f)
 
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .fillMaxSize()
-                .background(SDGColor.Neutral0_a60)
-        ) {
-            SDGSystemProgress(
-                modifier = Modifier.align(Alignment.Center)
-            )
-        }
+        SDGSystemProgressPopupContent()
     }
+}
+
+@Composable
+private fun SDGSystemProgressPopupContent() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SDGColor.Neutral0_a60)
+    ) {
+        SDGSystemProgress(
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}
+
+/**
+ * Compose Preview에서 Dialog 대신 System Progress Popup 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGSystemProgressPopupInspectionPreview() {
+    SDGSystemProgressPopupContent()
 }
 
 @Preview(name = "interactive mode로 확인")

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/SDGBottomPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/SDGBottomPopup.kt
@@ -1,5 +1,6 @@
 package com.shopl.sdg.template.popup
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,9 +14,11 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.shopl.sdg_common.foundation.SDGColor
@@ -23,6 +26,7 @@ import com.shopl.sdg_common.foundation.SDGCornerRadius
 import com.shopl.sdg_common.foundation.spacing.SDGSpacing
 import com.shopl.sdg_common.foundation.typography.SDGTypography
 import com.shopl.sdg_common.ui.components.SDGText
+import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 import com.shopl.sdg_resource.R
 
 /**
@@ -59,6 +63,21 @@ fun SDGBottomPopup(
     isConfirmEnable: Boolean = true,
     confirmLabelColor: Color = SDGColor.Neutral700,
 ) {
+    if (LocalInspectionMode.current) {
+        SDGBottomPopupInspectionPreview(
+            singleButton = singleButton,
+            onClickConfirm = onClickConfirm,
+            content = content,
+            containerColor = containerColor,
+            cancelLabel = cancelLabel,
+            confirmLabel = confirmLabel,
+            onClickCancel = onClickCancel,
+            isConfirmEnable = isConfirmEnable,
+            confirmLabelColor = confirmLabelColor,
+        )
+        return
+    }
+
     ModalBottomSheet(
         onDismissRequest = onClickCancel ?: onClickConfirm,
         modifier = modifier,
@@ -72,34 +91,96 @@ fun SDGBottomPopup(
         scrimColor = SDGColor.Neutral900_a40,
         dragHandle = null,
     ) {
-        Column(
+        SDGBottomPopupContent(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding(),
+            singleButton = singleButton,
+            onClickConfirm = onClickConfirm,
+            content = content,
+            cancelLabel = cancelLabel,
+            confirmLabel = confirmLabel,
+            onClickCancel = onClickCancel,
+            isConfirmEnable = isConfirmEnable,
+            confirmLabelColor = confirmLabelColor,
+        )
+    }
+}
+
+@Composable
+private fun SDGBottomPopupContent(
+    modifier: Modifier,
+    singleButton: Boolean,
+    onClickConfirm: () -> Unit,
+    content: @Composable () -> Unit,
+    cancelLabel: String,
+    confirmLabel: String,
+    onClickCancel: (() -> Unit)?,
+    isConfirmEnable: Boolean,
+    confirmLabelColor: Color,
+) {
+    Column(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = SDGSpacing.Spacing24,
+                    top = SDGSpacing.Spacing24,
+                    end = SDGSpacing.Spacing24,
+                    bottom = SDGSpacing.Spacing28
+                ),
+        ) {
+            content()
+        }
+        SDGPopupBottomButton(
+            singleButton = singleButton,
+            cancelLabel = cancelLabel,
+            confirmLabel = confirmLabel,
+            onClickCancel = onClickCancel,
+            onClickConfirm = onClickConfirm,
+            isConfirmEnable = isConfirmEnable,
+            confirmLabelColor = confirmLabelColor,
+            isBottomDialog = true
+        )
+    }
+}
+
+/**
+ * Compose Preview에서 ModalBottomSheet 대신 Bottom Popup 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGBottomPopupInspectionPreview(
+    singleButton: Boolean,
+    onClickConfirm: () -> Unit,
+    content: @Composable () -> Unit,
+    containerColor: Color,
+    cancelLabel: String,
+    confirmLabel: String,
+    onClickCancel: (() -> Unit)?,
+    isConfirmEnable: Boolean,
+    confirmLabelColor: Color,
+) {
+    SDGPopupPreviewContainer(contentAlignment = Alignment.BottomCenter) {
+        SDGBottomPopupContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        start = SDGSpacing.Spacing24,
-                        top = SDGSpacing.Spacing24,
-                        end = SDGSpacing.Spacing24,
-                        bottom = SDGSpacing.Spacing28
-                    ),
-            ) {
-                content()
-            }
-            SDGPopupBottomButton(
-                singleButton = singleButton,
-                cancelLabel = cancelLabel,
-                confirmLabel = confirmLabel,
-                onClickCancel = onClickCancel,
-                onClickConfirm = onClickConfirm,
-                isConfirmEnable = isConfirmEnable,
-                confirmLabelColor = confirmLabelColor,
-                isBottomDialog = true
-            )
-        }
+                .background(
+                    color = containerColor,
+                    shape = RoundedCornerShape(
+                        topStart = SDGCornerRadius.Radius20,
+                        topEnd = SDGCornerRadius.Radius20
+                    )
+                ),
+            singleButton = singleButton,
+            onClickConfirm = onClickConfirm,
+            content = content,
+            cancelLabel = cancelLabel,
+            confirmLabel = confirmLabel,
+            onClickCancel = onClickCancel,
+            isConfirmEnable = isConfirmEnable,
+            confirmLabelColor = confirmLabelColor,
+        )
     }
 }
 

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/SDGPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/SDGPopup.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import com.shopl.sdg_common.ext.clickable
 import com.shopl.sdg_common.foundation.SDGColor
+import com.shopl.sdg_common.foundation.SDGCornerRadius
 import com.shopl.sdg_common.foundation.typography.SDGTypography
 import com.shopl.sdg_common.ui.components.IOText
 import com.shopl.sdg_common.ui.components.IOTypeface
@@ -293,7 +294,7 @@ private fun SDGPopupContent(
             .widthIn(max = (LocalConfiguration.current.screenWidthDp - 40).dp)
             .background(
                 color = SDGColor.Neutral0,
-                shape = RoundedCornerShape(20.dp)
+                shape = RoundedCornerShape(SDGCornerRadius.Radius20)
             )
     ) {
         Box(

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/SDGPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/SDGPopup.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
@@ -48,6 +49,7 @@ import com.shopl.sdg_common.foundation.typography.SDGTypography
 import com.shopl.sdg_common.ui.components.IOText
 import com.shopl.sdg_common.ui.components.IOTypeface
 import com.shopl.sdg_common.ui.components.SDGText
+import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 import com.shopl.sdg_common.util.textCenterAlignment
 import com.shopl.sdg_resource.R
 
@@ -220,6 +222,22 @@ fun SDGPopup(
     contentPadding: PaddingValues = PaddingValues(horizontal = 28.dp, vertical = 32.dp),
     content: @Composable () -> Unit,
 ) {
+    if (LocalInspectionMode.current) {
+        SDGPopupInspectionPreview(
+            modifier = modifier,
+            singleButton = singleButton,
+            isConfirmEnable = isConfirmEnable,
+            confirmLabelColor = confirmLabelColor,
+            cancelLabel = cancelLabel,
+            confirmLabel = confirmLabel,
+            onClickCancel = onClickCancel,
+            onClickConfirm = onClickConfirm,
+            contentPadding = contentPadding,
+            content = content,
+        )
+        return
+    }
+
     Dialog(
         onDismissRequest = {
             onDismissRequest?.let {
@@ -240,33 +258,60 @@ fun SDGPopup(
     ) {
         (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.4f)
 
-        Column(
-            modifier = modifier
-                .padding(horizontal = 20.dp)
-                .heightIn(max = (LocalConfiguration.current.screenHeightDp - 120).dp)
-                .widthIn(max = (LocalConfiguration.current.screenWidthDp - 40).dp)
-                .background(
-                    color = SDGColor.Neutral0,
-                    shape = RoundedCornerShape(20.dp)
-                )
-        ) {
-            Box(
-                modifier = Modifier
-                    .weight(1f, false)
-                    .padding(contentPadding)
-            ) {
-                content.invoke()
-            }
-            SDGPopupBottomButton(
-                singleButton = singleButton,
-                cancelLabel = cancelLabel,
-                confirmLabel = confirmLabel,
-                onClickCancel = onClickCancel,
-                onClickConfirm = onClickConfirm,
-                isConfirmEnable = isConfirmEnable,
-                confirmLabelColor = confirmLabelColor
+        SDGPopupContent(
+            modifier = modifier,
+            singleButton = singleButton,
+            isConfirmEnable = isConfirmEnable,
+            confirmLabelColor = confirmLabelColor,
+            cancelLabel = cancelLabel,
+            confirmLabel = confirmLabel,
+            onClickCancel = onClickCancel,
+            onClickConfirm = onClickConfirm,
+            contentPadding = contentPadding,
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun SDGPopupContent(
+    modifier: Modifier = Modifier,
+    singleButton: Boolean,
+    isConfirmEnable: Boolean,
+    confirmLabelColor: Color,
+    cancelLabel: String,
+    confirmLabel: String,
+    onClickCancel: (() -> Unit)?,
+    onClickConfirm: () -> Unit,
+    contentPadding: PaddingValues,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 20.dp)
+            .heightIn(max = (LocalConfiguration.current.screenHeightDp - 120).dp)
+            .widthIn(max = (LocalConfiguration.current.screenWidthDp - 40).dp)
+            .background(
+                color = SDGColor.Neutral0,
+                shape = RoundedCornerShape(20.dp)
             )
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f, false)
+                .padding(contentPadding)
+        ) {
+            content.invoke()
         }
+        SDGPopupBottomButton(
+            singleButton = singleButton,
+            cancelLabel = cancelLabel,
+            confirmLabel = confirmLabel,
+            onClickCancel = onClickCancel,
+            onClickConfirm = onClickConfirm,
+            isConfirmEnable = isConfirmEnable,
+            confirmLabelColor = confirmLabelColor
+        )
     }
 }
 
@@ -427,6 +472,38 @@ fun SDGPopupBodyBullet(
             fontSize = fontSize,
             typeface = typeface,
             onTextLayout = { textLayoutResult = it }
+        )
+    }
+}
+
+/**
+ * Compose Preview에서 Dialog 대신 Popup 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGPopupInspectionPreview(
+    modifier: Modifier = Modifier,
+    singleButton: Boolean,
+    isConfirmEnable: Boolean,
+    confirmLabelColor: Color,
+    cancelLabel: String,
+    confirmLabel: String,
+    onClickCancel: (() -> Unit)?,
+    onClickConfirm: () -> Unit,
+    contentPadding: PaddingValues,
+    content: @Composable () -> Unit,
+) {
+    SDGPopupPreviewContainer(contentAlignment = Alignment.Center) {
+        SDGPopupContent(
+            modifier = modifier,
+            singleButton = singleButton,
+            isConfirmEnable = isConfirmEnable,
+            confirmLabelColor = confirmLabelColor,
+            cancelLabel = cancelLabel,
+            confirmLabel = confirmLabel,
+            onClickCancel = onClickCancel,
+            onClickConfirm = onClickConfirm,
+            contentPadding = contentPadding,
+            content = content,
         )
     }
 }

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/SDGProgressPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/SDGProgressPopup.kt
@@ -6,17 +6,25 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import com.shopl.sdg_common.foundation.SDGColor
+import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 
 @Composable
 fun SDGProgressPopup(
     withDim: Boolean = false
 ) {
+    if (LocalInspectionMode.current) {
+        SDGProgressPopupInspectionPreview(withDim = withDim)
+        return
+    }
+
     Dialog(
         onDismissRequest = { },
         DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
@@ -26,15 +34,39 @@ fun SDGProgressPopup(
         } else {
             (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.4F)
         }
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .size(32.dp)
-        ) {
-            CircularProgressIndicator(
-                color = SDGColor.Primary300,
-                modifier = Modifier.align(Alignment.Center)
-            )
-        }
+        SDGProgressPopupContent()
     }
+}
+
+@Composable
+private fun SDGProgressPopupContent() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(32.dp)
+    ) {
+        CircularProgressIndicator(
+            color = SDGColor.Primary300,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}
+
+/**
+ * Compose Preview에서 Dialog 대신 Progress Popup 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGProgressPopupInspectionPreview(withDim: Boolean) {
+    SDGPopupPreviewContainer(
+        contentAlignment = Alignment.Center,
+        withDim = withDim
+    ) {
+        SDGProgressPopupContent()
+    }
+}
+
+@Preview(name = "SDGProgressPopup", widthDp = 360, heightDp = 640)
+@Composable
+private fun PreviewSDGProgressPopup() {
+    SDGProgressPopup(withDim = true)
 }

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/bottom/SDGBottomPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/bottom/SDGBottomPopup.kt
@@ -1,5 +1,6 @@
 package com.shopl.sdg.template.popup.bottom
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,8 +14,10 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,6 +30,7 @@ import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing28
 import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing4
 import com.shopl.sdg_common.foundation.typography.SDGTypography
 import com.shopl.sdg_common.ui.components.SDGText
+import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 
 private const val MAX_SHEET_HEIGHT_RATIO = 0.8f
 
@@ -57,6 +61,16 @@ fun SDGBottomPopup(
     sheetState: SheetState = rememberModalBottomSheetState(),
     body: @Composable (ColumnScope.() -> Unit),
 ) {
+    if (LocalInspectionMode.current) {
+        SDGBottomPopupInspectionPreview(
+            buttonOption = buttonOption,
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body,
+        )
+        return
+    }
+
     val containerSize = LocalWindowInfo.current.containerSize
     val density = LocalDensity.current.density
     val screenHeight = (containerSize.height / density).dp
@@ -73,43 +87,97 @@ fun SDGBottomPopup(
         scrimColor = SDGColor.Neutral900_a40,
         dragHandle = null,
     ) {
-        val bodyTopPadding = if (title.isNullOrBlank()) Spacing24 else Spacing12
+        SDGBottomPopupContent(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = maxSheetHeight),
+            buttonOption = buttonOption,
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body,
+        )
+    }
+}
+
+@Composable
+private fun SDGBottomPopupContent(
+    modifier: Modifier,
+    buttonOption: SDGBottomPopupButtonOption,
+    title: String?,
+    titleAlignment: TextAlign,
+    body: @Composable (ColumnScope.() -> Unit),
+) {
+    val bodyTopPadding = if (title.isNullOrBlank()) Spacing24 else Spacing12
+
+    Column(modifier = modifier) {
+        if (!title.isNullOrBlank()) {
+            SDGText(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Spacing24, start = Spacing24, end = Spacing24),
+                text = title,
+                typography = SDGTypography.Title2SB,
+                textColor = SDGColor.Neutral700,
+                textAlign = titleAlignment,
+            )
+        }
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(max = maxSheetHeight)
-        ) {
-            if (!title.isNullOrBlank()) {
-                SDGText(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = Spacing24, start = Spacing24, end = Spacing24),
-                    text = title,
-                    typography = SDGTypography.Title2SB,
-                    textColor = SDGColor.Neutral700,
-                    textAlign = titleAlignment,
+                .weight(weight = 1f, fill = false)
+                .padding(top = bodyTopPadding)
+                .verticalScroll(state = rememberScrollState())
+                .padding(
+                    top = Spacing4,
+                    start = Spacing24,
+                    end = Spacing24,
+                    bottom = Spacing28,
                 )
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(weight = 1f, fill = false)
-                    .padding(top = bodyTopPadding)
-                    .verticalScroll(state = rememberScrollState())
-                    .padding(
-                        top = Spacing4,
-                        start = Spacing24,
-                        end = Spacing24,
-                        bottom = Spacing28,
-                    )
-            ) {
-                body()
-            }
-
-            SDGBottomPopupButton(option = buttonOption)
+        ) {
+            body()
         }
+
+        SDGBottomPopupButton(option = buttonOption)
+    }
+}
+
+/**
+ * Compose Preview에서 ModalBottomSheet 대신 Bottom Popup 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGBottomPopupInspectionPreview(
+    buttonOption: SDGBottomPopupButtonOption,
+    title: String? = null,
+    titleAlignment: TextAlign = TextAlign.Left,
+    body: @Composable (ColumnScope.() -> Unit),
+) {
+    val containerSize = LocalWindowInfo.current.containerSize
+    val density = LocalDensity.current.density
+    val previewScreenHeight = if (containerSize.height == 0) {
+        640.dp
+    } else {
+        (containerSize.height / density).dp
+    }
+    val previewMaxSheetHeight = previewScreenHeight * MAX_SHEET_HEIGHT_RATIO
+
+    SDGPopupPreviewContainer(contentAlignment = Alignment.BottomCenter) {
+        SDGBottomPopupContent(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = previewMaxSheetHeight)
+                .background(
+                    color = SDGColor.Neutral0,
+                    shape = RoundedCornerShape(
+                        topStart = SDGCornerRadius.Radius20,
+                        topEnd = SDGCornerRadius.Radius20
+                    )
+                ),
+            buttonOption = buttonOption,
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body,
+        )
     }
 }
 

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
@@ -79,7 +79,7 @@ fun SDGCenterPopup(
 
         val containerSize = LocalWindowInfo.current.containerSize
         val density = LocalDensity.current.density
-        val screenHeight = containerSize.height.dp / density
+        val screenHeight = (containerSize.height / density).dp
 
         SDGCenterPopupContent(
             buttonOption = buttonOption,

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
@@ -10,13 +10,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -30,6 +33,7 @@ import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing12
 import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing24
 import com.shopl.sdg_common.foundation.typography.SDGTypography
 import com.shopl.sdg_common.ui.components.SDGText
+import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 
 /**
  * SDG - Popup - Center Popup
@@ -47,6 +51,16 @@ fun SDGCenterPopup(
     titleAlignment: TextAlign = TextAlign.Left,
     body: @Composable (ColumnScope.() -> Unit)?,
 ) {
+    if (LocalInspectionMode.current) {
+        SDGCenterPopupInspectionPreview(
+            buttonOption = buttonOption,
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body
+        )
+        return
+    }
+
     Dialog(
         onDismissRequest = {
             when (buttonOption) {
@@ -67,40 +81,57 @@ fun SDGCenterPopup(
         val density = LocalDensity.current.density
         val screenHeight = containerSize.height.dp / density
 
-        Column(
-            modifier = Modifier
-                .padding(horizontal = SDGSpacing.Spacing20)
-                .heightIn(max = screenHeight - 160.dp)
-                .background(
-                    color = SDGColor.Neutral0,
-                    shape = RoundedCornerShape(SDGCornerRadius.Radius20)
-                )
-                .padding(top = Spacing24)
-        ) {
-            if (!title.isNullOrBlank()) {
-                SDGCenterPopupTitle(
-                    modifier = Modifier
-                        .padding(horizontal = Spacing24)
-                        .padding(bottom = if (body == null) Spacing24 else Spacing12),
-                    title = title,
-                    titleAlignment = titleAlignment
-                )
-            }
+        SDGCenterPopupContent(
+            buttonOption = buttonOption,
+            maxHeight = screenHeight - 160.dp,
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body
+        )
+    }
+}
 
-            body?.let {
-                Column(
-                    modifier = Modifier
-                        .padding(horizontal = Spacing24)
-                        .weight(1f, false)
-                        .verticalScroll(rememberScrollState())
-                        .padding(top = SDGSpacing.Spacing4, bottom = SDGSpacing.Spacing28)
-                ) {
-                    it()
-                }
-            }
-
-            SDGCenterPopupButton(buttonOption)
+@Composable
+private fun SDGCenterPopupContent(
+    buttonOption: SDGCenterPopupButtonOption,
+    maxHeight: Dp,
+    title: String? = null,
+    titleAlignment: TextAlign = TextAlign.Left,
+    body: @Composable (ColumnScope.() -> Unit)?,
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = SDGSpacing.Spacing20)
+            .heightIn(max = maxHeight)
+            .background(
+                color = SDGColor.Neutral0,
+                shape = RoundedCornerShape(SDGCornerRadius.Radius20)
+            )
+            .padding(top = Spacing24)
+    ) {
+        if (!title.isNullOrBlank()) {
+            SDGCenterPopupTitle(
+                modifier = Modifier
+                    .padding(horizontal = Spacing24)
+                    .padding(bottom = if (body == null) Spacing24 else Spacing12),
+                title = title,
+                titleAlignment = titleAlignment
+            )
         }
+
+        body?.let {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = Spacing24)
+                    .weight(1f, false)
+                    .verticalScroll(rememberScrollState())
+                    .padding(top = SDGSpacing.Spacing4, bottom = SDGSpacing.Spacing28)
+            ) {
+                it()
+            }
+        }
+
+        SDGCenterPopupButton(buttonOption)
     }
 }
 
@@ -117,6 +148,35 @@ private fun SDGCenterPopupTitle(
         textColor = SDGColor.Neutral700,
         textAlign = titleAlignment
     )
+}
+
+/**
+ * Compose Preview에서 Dialog 대신 Center Popup 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGCenterPopupInspectionPreview(
+    buttonOption: SDGCenterPopupButtonOption,
+    title: String? = null,
+    titleAlignment: TextAlign = TextAlign.Left,
+    body: @Composable (ColumnScope.() -> Unit)?,
+) {
+    val containerSize = LocalWindowInfo.current.containerSize
+    val density = LocalDensity.current.density
+    val screenHeight = if (containerSize.height == 0) {
+        640.dp
+    } else {
+        containerSize.height.dp / density
+    }
+
+    SDGPopupPreviewContainer(contentAlignment = Alignment.Center) {
+        SDGCenterPopupContent(
+            buttonOption = buttonOption,
+            maxHeight = (screenHeight - 160.dp).coerceAtLeast(0.dp),
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body
+        )
+    }
 }
 
 @Preview

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/center/SDGCenterPopup.kt
@@ -83,7 +83,7 @@ fun SDGCenterPopup(
 
         SDGCenterPopupContent(
             buttonOption = buttonOption,
-            maxHeight = screenHeight - 160.dp,
+            maxHeight = (screenHeight - 160.dp).coerceAtLeast(0.dp),
             title = title,
             titleAlignment = titleAlignment,
             body = body

--- a/sdg/src/main/java/com/shopl/sdg/template/popup/list/anatomy/SDGListBottomSheet.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/popup/list/anatomy/SDGListBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.shopl.sdg.template.popup.list.anatomy
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,14 +20,18 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.shopl.sdg.template.util.list_popup_item_ui_state.SDGListPopupItemUiState
 import com.shopl.sdg_common.foundation.SDGColor
 import com.shopl.sdg_common.foundation.SDGCornerRadius
 import com.shopl.sdg_common.foundation.spacing.SDGSpacing
+import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -46,11 +51,21 @@ fun SDGListBottomSheet(
         skipPartiallyExpanded = true
     )
 ) {
+    if (LocalInspectionMode.current) {
+        SDGListBottomSheetInspectionPreview(
+            items = items,
+            onSelected = onSelected,
+            onDismissRequest = onDismissRequest,
+        )
+        return
+    }
+
     val windowInfo = LocalWindowInfo.current
     val density = LocalDensity.current
     val maxHeight = with(density) {
         (windowInfo.containerSize.height * 0.7f).toDp()
     }
+
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
@@ -64,21 +79,33 @@ fun SDGListBottomSheet(
         dragHandle = null,
         modifier = Modifier.fillMaxWidth()
     ) {
-        Column(
+        SDGListBottomSheetContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(max = maxHeight)
-                .navigationBarsPadding()
-        ) {
-            SDGSelectableTextList(
-                items = items,
-                onSelected = onSelected,
-                onDismissRequest = onDismissRequest
-            )
-        }
+                .navigationBarsPadding(),
+            items = items,
+            onSelected = onSelected,
+            onDismissRequest = onDismissRequest,
+        )
     }
 }
 
+@Composable
+private fun SDGListBottomSheetContent(
+    modifier: Modifier,
+    items: PersistentList<SDGListPopupItemUiState>,
+    onSelected: (SDGListPopupItemUiState) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    Column(modifier = modifier) {
+        SDGSelectableTextList(
+            items = items,
+            onSelected = onSelected,
+            onDismissRequest = onDismissRequest
+        )
+    }
+}
 
 @Composable
 private fun SDGSelectableTextList(
@@ -109,6 +136,45 @@ private fun SDGSelectableTextList(
                 )
             }
         }
+    }
+}
+
+/**
+ * Compose Preview에서 ModalBottomSheet 대신 List Bottom Sheet 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGListBottomSheetInspectionPreview(
+    items: PersistentList<SDGListPopupItemUiState>,
+    onSelected: (SDGListPopupItemUiState) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    val windowInfo = LocalWindowInfo.current
+    val density = LocalDensity.current
+    val previewMaxHeight = with(density) {
+        if (windowInfo.containerSize.height == 0) {
+            448.dp
+        } else {
+            (windowInfo.containerSize.height * 0.7f).toDp()
+        }
+    }
+
+    SDGPopupPreviewContainer(contentAlignment = Alignment.BottomCenter) {
+        SDGListBottomSheetContent(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = previewMaxHeight)
+                .navigationBarsPadding()
+                .background(
+                    color = SDGColor.Neutral0,
+                    shape = RoundedCornerShape(
+                        topStart = SDGCornerRadius.Radius20,
+                        topEnd = SDGCornerRadius.Radius20
+                    )
+                ),
+            items = items,
+            onSelected = onSelected,
+            onDismissRequest = onDismissRequest,
+        )
     }
 }
 

--- a/sdg/src/main/java/com/shopl/sdg/template/util/popup/SDGCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/util/popup/SDGCenterPopup.kt
@@ -98,7 +98,7 @@ fun SDGCenterPopup(
         SDGCenterPopupContent(
             buttonOption = buttonOption,
             itemSpacing = itemSpacing,
-            maxHeight = screenHeight - 160.dp,
+            maxHeight = (screenHeight - 160.dp).coerceAtLeast(0.dp),
             title = title,
             titleAlignment = titleAlignment,
             body = body,

--- a/sdg/src/main/java/com/shopl/sdg/template/util/popup/SDGCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/util/popup/SDGCenterPopup.kt
@@ -93,7 +93,7 @@ fun SDGCenterPopup(
 
         val containerSize = LocalWindowInfo.current.containerSize
         val density = LocalDensity.current.density
-        val screenHeight = containerSize.height.dp / density
+        val screenHeight = (containerSize.height / density).dp
 
         SDGCenterPopupContent(
             buttonOption = buttonOption,

--- a/sdg/src/main/java/com/shopl/sdg/template/util/popup/SDGCenterPopup.kt
+++ b/sdg/src/main/java/com/shopl/sdg/template/util/popup/SDGCenterPopup.kt
@@ -11,8 +11,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.style.TextAlign
@@ -34,6 +36,7 @@ import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing12
 import com.shopl.sdg_common.foundation.spacing.SDGSpacing.Spacing24
 import com.shopl.sdg_common.foundation.typography.SDGTypography
 import com.shopl.sdg_common.ui.components.SDGText
+import com.shopl.sdg_common.util.SDGPopupPreviewContainer
 
 /**
  * SDG - Popup - Center Popup
@@ -56,6 +59,17 @@ fun SDGCenterPopup(
     titleAlignment: TextAlign = TextAlign.Left,
     body: (LazyListScope.() -> Unit)?,
 ) {
+    if (LocalInspectionMode.current) {
+        SDGCenterPopupInspectionPreview(
+            buttonOption = buttonOption,
+            itemSpacing = itemSpacing,
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body,
+        )
+        return
+    }
+
     Dialog(
         onDismissRequest = {
             when (buttonOption) {
@@ -81,43 +95,62 @@ fun SDGCenterPopup(
         val density = LocalDensity.current.density
         val screenHeight = containerSize.height.dp / density
 
-        Column(
-            modifier = Modifier
-                .padding(horizontal = SDGSpacing.Spacing20)
-                .heightIn(max = screenHeight - 160.dp)
-                .background(
-                    color = SDGColor.Neutral0,
-                    shape = RoundedCornerShape(SDGCornerRadius.Radius20)
-                )
-                .padding(top = Spacing24)
-        ) {
-            if (!title.isNullOrBlank()) {
-                SDGCenterPopupTitle(
-                    modifier = Modifier
-                        .padding(horizontal = Spacing24)
-                        .padding(bottom = if (body == null) Spacing24 else Spacing12),
-                    title = title,
-                    titleAlignment = titleAlignment
-                )
-            }
+        SDGCenterPopupContent(
+            buttonOption = buttonOption,
+            itemSpacing = itemSpacing,
+            maxHeight = screenHeight - 160.dp,
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body,
+        )
+    }
+}
 
-            body?.let {
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(itemSpacing),
-                    modifier = Modifier
-                        .padding(horizontal = Spacing24)
-                        .weight(1f, false),
-                    contentPadding = PaddingValues(
-                        top = SDGSpacing.Spacing4,
-                        bottom = SDGSpacing.Spacing28
-                    )
-                ) {
-                    it()
-                }
-            }
-
-            SDGCenterPopupButton(buttonOption)
+@Composable
+private fun SDGCenterPopupContent(
+    buttonOption: SDGCenterPopupButtonOption,
+    itemSpacing: Dp,
+    maxHeight: Dp,
+    title: String? = null,
+    titleAlignment: TextAlign = TextAlign.Left,
+    body: (LazyListScope.() -> Unit)?,
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = SDGSpacing.Spacing20)
+            .heightIn(max = maxHeight)
+            .background(
+                color = SDGColor.Neutral0,
+                shape = RoundedCornerShape(SDGCornerRadius.Radius20)
+            )
+            .padding(top = Spacing24)
+    ) {
+        if (!title.isNullOrBlank()) {
+            SDGCenterPopupTitle(
+                modifier = Modifier
+                    .padding(horizontal = Spacing24)
+                    .padding(bottom = if (body == null) Spacing24 else Spacing12),
+                title = title,
+                titleAlignment = titleAlignment
+            )
         }
+
+        body?.let {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(itemSpacing),
+                modifier = Modifier
+                    .padding(horizontal = Spacing24)
+                    .weight(1f, false),
+                contentPadding = PaddingValues(
+                    top = SDGSpacing.Spacing4,
+                    bottom = SDGSpacing.Spacing28
+                )
+            ) {
+                it()
+            }
+        }
+
+        SDGCenterPopupButton(buttonOption)
     }
 }
 
@@ -134,6 +167,37 @@ private fun SDGCenterPopupTitle(
         textColor = SDGColor.Neutral700,
         textAlign = titleAlignment
     )
+}
+
+/**
+ * Compose Preview에서 Dialog 대신 Lazy 기반 Center Popup 콘텐츠를 인라인으로 렌더링합니다.
+ */
+@Composable
+private fun SDGCenterPopupInspectionPreview(
+    buttonOption: SDGCenterPopupButtonOption,
+    itemSpacing: Dp,
+    title: String? = null,
+    titleAlignment: TextAlign = TextAlign.Left,
+    body: (LazyListScope.() -> Unit)?,
+) {
+    val containerSize = LocalWindowInfo.current.containerSize
+    val density = LocalDensity.current.density
+    val screenHeight = if (containerSize.height == 0) {
+        640.dp
+    } else {
+        containerSize.height.dp / density
+    }
+
+    SDGPopupPreviewContainer(contentAlignment = Alignment.Center) {
+        SDGCenterPopupContent(
+            buttonOption = buttonOption,
+            itemSpacing = itemSpacing,
+            maxHeight = (screenHeight - 160.dp).coerceAtLeast(0.dp),
+            title = title,
+            titleAlignment = titleAlignment,
+            body = body,
+        )
+    }
 }
 
 @Preview


### PR DESCRIPTION
## JIRA
[SH-21248](https://shoplworks.atlassian.net/browse/SH-21248)

## 작업사항
- Dialog / ModalBottomSheet 기반 팝업이 Preview에서 렌더링되지 않던 문제 수정
- Preview 환경(`LocalInspectionMode`)에서는 실제 Dialog/BottomSheet 대신 인라인 preview container를 통해 팝업 콘텐츠가 표시되도록 처리했습니다.
- 런타임에서 사용되는 팝업 내부 UI와 Preview에서 사용되는 UI가 동일한 Content 구현을 공유하도록 분리했습니다.
- `SDGPopupPreviewContainer`를 공통화하여 center popup, bottom popup, list bottom sheet, progress popup preview 처리에 재사용했습니다.

| Before | After |
| --- | --- |
| Dialog 기반 팝업이 Preview에서 렌더링되지 않음 | 동일한 public popup API 호출만으로 Preview에서 팝업 콘텐츠 렌더링 |
| <img src="https://github.com/user-attachments/assets/c352a062-efca-42f3-a834-a860a4fe554c" width="320" /> | <img src="https://github.com/user-attachments/assets/b89b1395-df56-4e59-9e20-721aa9ea49b0" width="320" /> |

[SH-21248]: https://shoplworks.atlassian.net/browse/SH-21248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ