### PR TITLE
Verify Jira PR title lookup

### DIFF
--- a/.github/workflows/create_pr.yml
+++ b/.github/workflows/create_pr.yml
@@ -4,13 +4,17 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   auto-title:
     runs-on: ubuntu-latest
 
     steps:
       - name: Jira 이슈 summary로 PR 타이틀 업데이트
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -22,65 +26,112 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const branchName = context.payload.pull_request.head.ref;
 
-            // 이슈번호 추출 (예: SH-1115)
-            let issueKey = null;
-            try {
-              const issueMatch = branchName.match(/(SH-\d{1,})/);
-              issueKey = issueMatch ? issueMatch[1] : null;
-              console.log('이슈번호:', issueKey);
-            } catch (e) {
-              console.log('이슈번호 추출 실패:', e);
+            const issueMatch = branchName.match(/\b(SH-\d+)\b/i);
+            const issueKey = issueMatch ? issueMatch[1].toUpperCase() : null;
+
+            if (!issueKey) {
+              console.log(`브랜치명에서 Jira 이슈 키를 찾지 못했습니다: ${branchName}`);
+              return;
             }
 
-            // Jira 이슈 summary 가져오기
-            let jiraTitle = null;
-            try {
-              if (issueKey) {
-                const jiraBaseUrl = process.env.JIRA_BASE_URL;
-                const jiraEmail = process.env.JIRA_EMAIL;
-                const jiraToken = process.env.JIRA_API_TOKEN;
+            console.log('이슈번호:', issueKey);
 
-                const basicAuth = Buffer.from(`${jiraEmail}:${jiraToken}`).toString('base64');
-                const res = await fetch(
-                  `${jiraBaseUrl}/rest/api/3/issue/${issueKey}`,
-                  {
-                    method: 'GET',
-                    headers: {
-                      'Authorization': `Basic ${basicAuth}`,
-                      'Accept': 'application/json'
-                    }
-                  }
-                );
+            const requiredEnv = ['JIRA_BASE_URL', 'JIRA_EMAIL', 'JIRA_API_TOKEN'];
+            const missingEnv = requiredEnv.filter(name => !process.env[name]);
 
-                if (res.ok) {
-                  const data = await res.json();
-                  jiraTitle = data.fields.summary;
+            if (missingEnv.length > 0) {
+              throw new Error(`Jira summary 조회에 필요한 환경변수가 없습니다: ${missingEnv.join(', ')}`);
+            }
+
+            const formatJiraError = (body) => {
+              if (!body) {
+                return '';
+              }
+
+              try {
+                const parsed = JSON.parse(body);
+                const messages = [
+                  ...(Array.isArray(parsed.errorMessages) ? parsed.errorMessages : []),
+                  ...(parsed.errors ? Object.values(parsed.errors) : [])
+                ].filter(Boolean);
+
+                if (messages.length > 0) {
+                  return messages.join(' / ');
+                }
+
+                return JSON.stringify(parsed);
+              } catch (e) {
+                return body;
+              }
+            };
+
+            const normalizeJiraBaseUrl = (value) => {
+              const withProtocol = /^https?:\/\//i.test(value)
+                ? value
+                : `https://${value}`;
+
+              return new URL(withProtocol).origin;
+            };
+
+            const jiraBaseUrl = normalizeJiraBaseUrl(process.env.JIRA_BASE_URL.trim());
+            const jiraEmail = process.env.JIRA_EMAIL;
+            const jiraToken = process.env.JIRA_API_TOKEN;
+            const jiraIssueUrl = `${jiraBaseUrl}/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=summary`;
+            const basicAuth = Buffer.from(`${jiraEmail}:${jiraToken}`).toString('base64');
+            const res = await fetch(
+              jiraIssueUrl,
+              {
+                method: 'GET',
+                headers: {
+                  'Authorization': `Basic ${basicAuth}`,
+                  'Accept': 'application/json'
                 }
               }
-            } catch (e) {
-              console.log('Jira summary 조회 실패:', e);
+            );
+
+            const body = await res.text();
+
+            if (!res.ok) {
+              const details = formatJiraError(body)
+                .replace(/\s+/g, ' ')
+                .trim()
+                .slice(0, 500);
+              const suffix = details ? ` - ${details}` : '';
+              throw new Error(`Jira summary 조회 실패: ${issueKey} HTTP ${res.status} ${res.statusText}${suffix}`);
             }
 
-            // PR 타이틀: [SH-1115] 이슈 summary
-            let prTitle = null;
+            let jiraIssue = null;
             try {
-              prTitle = (issueKey && jiraTitle) ? `[${issueKey}] ${jiraTitle}` :
-                        (issueKey ? `[${issueKey}]` : context.payload.pull_request.title);
-
-              if (context.payload.pull_request.title !== prTitle) {
-                await github.rest.pulls.update({
-                  owner,
-                  repo,
-                  pull_number: prNumber,
-                  title: prTitle
-                });
-              }
+              jiraIssue = JSON.parse(body);
             } catch (e) {
-              console.log('PR 타이틀 업데이트 실패:', e);
+              throw new Error(`Jira summary 응답을 JSON으로 파싱하지 못했습니다: ${issueKey}`);
             }
+
+            const jiraTitle = jiraIssue.fields?.summary?.trim();
+
+            if (!jiraTitle) {
+              throw new Error(`Jira summary가 비어 있습니다: ${issueKey}`);
+            }
+
+            const prTitle = `[${issueKey}] ${jiraTitle}`;
+
+            if (context.payload.pull_request.title === prTitle) {
+              console.log(`PR 타이틀이 이미 최신 상태입니다: ${prTitle}`);
+              return;
+            }
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: prNumber,
+              title: prTitle
+            });
+
+            console.log(`PR 타이틀 업데이트 완료: ${prTitle}`);
 
       - name: 리뷰어/Assignee
-        uses: actions/github-script@v6
+        if: ${{ always() && github.event.pull_request.draft == false }}
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GIT_DEV_TOKEN }}
           script: |


### PR DESCRIPTION
Fixes the PR Info workflow so Jira summary lookup builds the Jira API URL robustly and fails visibly when the lookup cannot succeed.